### PR TITLE
コメント者の画像にリンク追加し、ログインユーザー以外のユーザーのマイページも閲覧可能にした

### DIFF
--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -68,8 +68,10 @@ export const Comment = () => {
             <div className="comment-list__item">
               <div className="comment-list__item-head">
                 <div className='comment-user'>
-                  <img className='comment-user__img' src={comment.profilePictureUrl} alt="" />
-                  <p className="comment-user__name">{comment.userName}</p>
+                  <Link to={`/${comment.userId}`} className='comment-user__img'>
+                    <img className='' src={comment.profilePictureUrl} alt="" />
+                  </Link>
+                    <p className="comment-user__name">{comment.userName}</p>
                 </div>
                 <p className="comment-date">{comment.createdAt ?  comment.createdAt.toDate().toLocaleString() : ""}</p>
               </div>
@@ -79,10 +81,6 @@ export const Comment = () => {
         </div>
         {/* ログインしているユーザーのidと、今見ている記事のユーザーのidが一致すれば、「コメントを書く」ボタンを非表示にする。 */}
         {user &&
-            id === user.uid 
-                ?
-            ""
-                :
             <button className='comment-post' onClick={handleOpenModal}>
             <img className='comment-post__img' src="../../commentIcon.svg" alt="" />
             {/*ログインしていない時に「コメントを書く」ボタンを押すと、ログイン画面に遷移させる。  */}

--- a/src/components/login/Mypage.jsx
+++ b/src/components/login/Mypage.jsx
@@ -1,7 +1,7 @@
 // 各必要な要素を取得
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import React, { useContext, useEffect, useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useParams } from "react-router-dom";
 import "../../css/components/Mypage.css";
 import { auth } from "../../utils/firebase";
 import AppContext from "../../context/AppContext";
@@ -11,6 +11,7 @@ import GetUserInfo from "./GetUserInfo";
 
 //ログイン情報の取得
 const Mypage = () => {
+  const { id } = useParams(); 
   const navigate = useNavigate();
   const { user, loading } = useContext(AppContext);
   // Firebaseから取得した内容をpostsに代入
@@ -39,7 +40,7 @@ const Mypage = () => {
   useEffect(() => {
     // postsの中にあるコレクションの中からフィールドのauthorIdとログインしているuserと同じidの記事を取得
     //postsの中にあるisDraftがfalseを取得(公開済みの記事)
-    const q = query(collection(db, "posts"), where("authorId", "==", user.uid), where("isDraft", "==", false));
+    const q = query(collection(db, "posts"), where("authorId", "==", id), where("isDraft", "==", false));
 
     const unsubscribe = onSnapshot(q, (snapshot) => {
       const postsData = [];
@@ -52,22 +53,30 @@ const Mypage = () => {
     return () => {
       unsubscribe();
     };
-  }, [user]);
+  }, [user,id]);
 
   return (
     <div className="mypage">
       <h1 className="mypage__title">マイページ</h1>
-      <GetUserInfo />
-      <button onClick={handleSignOut} className="logout">
-        ログアウト
-      </button>
+      {user.uid === id 
+        ? 
+        <>
+          <GetUserInfo />
+            <button onClick={handleSignOut} className="logout">
+              ログアウト
+            </button>
+        </>
+        :
+        ""
+      }
+ 
 
       <div className="mypage-list">
         <h2>ブログ一覧</h2>
         <div className="mypage-list__items">
           {posts.map((post) => (
             <div key={post.id}>
-              <Link to={`/${user.uid}/posts/${post.id}`} className="mypage-list__link">
+              <Link to={`/${id}/posts/${post.id}`} className="mypage-list__link">
                 <div className="mypage-list__item">
                   <h3 className="mypage-list__item-title">{post.title}</h3>
                   <p className="mypage-list__item-content">{post.content}</p>

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -66,7 +66,7 @@ function Post({ EditPost }) {
       await deleteDoc(postDoc); // ドキュメントを削除
     }
 
-    navigate("/mypage"); // "/mypage"に移動
+    navigate(`/${user.uid}`); // "/mypage"に移動
   }
 
   // console.log(EditPost);

--- a/src/css/components/Comment.css
+++ b/src/css/components/Comment.css
@@ -28,9 +28,17 @@
     gap: 10px;
   }
 
-  .comment-user__img{
+  .comment-user__img img{
     width: 40px;
     border-radius: 50%;
+    }
+    
+  .comment-user__img{  
+    transition: 0.2s all;
+  }
+
+  .comment-user__img:hover{
+    opacity: 0.5;
   }
   
   .comment-user__name{


### PR DESCRIPTION
確認事項多くてすみませんが、よろしくお願いします。

追加機能
・コメント者の画像をクリックすると、そのユーザーのプロフィールページに飛べるようにしました。
・自分以外のユーザーのプロフィールページを見られるようにしました。
・記事を投稿すると、/mypageではなく/`${user.uid}`に遷移するようにした。
・自分以外のユーザーのマイページから、ユーザー情報変更ボタンやログアウトボタンを消した。

確認方法
1.コメント者のアイコンがリンクになっているか確認
2.コメント者のアイコンをクリックすると、ちゃんとコメント者のIDのページに遷移するか確認
4.コメント者のページには、ユーザー情報変更ボタンやログアウトボタンがないか確認
5.コメント者のページに遷移したのち、コメント者が投稿した記事をクリックすると、コメント者が投稿した記事がちゃんと見られるか
6.ヘッダーのマイページボタンを押すとちゃんとログインユーザーのマイページに遷移されるか確認